### PR TITLE
Fix numerous broken talk links in the archive

### DIFF
--- a/gathering/archive/2013/index.html
+++ b/gathering/archive/2013/index.html
@@ -12,8 +12,8 @@ title: MathsJam Gathering 2015
     <h4>Get Set - Sam Headleand and Robie Basak</h4>
     <p></p>
     <ul>
-        <li><a href="{{site.url}}/assets/talks/2013/Sam_Headleand_and_Robie_Basak_-_Get_Set.pdf">Slides (PDF)</a></li>
-        <li><a href="{{site.url}}/assets/talks/2013/Sam_Headleand_and_Robie_Basak_-_Get_Set.odp">Slides (ODP)</a></li>
+        <li><a href="{{site.url}}/assets/talks/2013/Sam%20Headleand%20and%20Robie%20Basak%20-%20Get%20Set.pdf">Slides (PDF)</a></li>
+        <li><a href="{{site.url}}/assets/talks/2013/Sam%20Headleand%20and%20Robie%20Basak%20-%20Get%20Set.odp">Slides (ODP)</a></li>
     </ul>
 </div>
 
@@ -30,8 +30,8 @@ title: MathsJam Gathering 2015
     <h4>Poetry in motion - Phil Ramsden</h4>
 	<p>A sestina is a seven-stanza poem, each of whose first six stanzas consist of six lines each. The sestina, and its intricate rhyme scheme, date back to the twelfth century.</p>
 	<ul>
-	    <li><a href="{{site.url}}/assets/talks/2013/Phil_Ramsden_-_Poetry_in_motion.pdf">Slides (PDF)</a></li>
-	    <li><a href="{{site.url}}/assets/talks/2013/Phil_Ramsden_-_Poetry_in_motion.pptx">Slides (PPTX)</a></li>
+	    <li><a href="{{site.url}}/assets/talks/2013/Phil%20Ramsden%20-%20Poetry%20in%20motion.pdf">Slides (PDF)</a></li>
+	    <li><a href="{{site.url}}/assets/talks/2013/Phil%20Ramsden%20-%20Poetry%20in%20motion.pptx">Slides (PPTX)</a></li>
 	</ul>
 </div>
 
@@ -39,8 +39,8 @@ title: MathsJam Gathering 2015
     <h4>Why John Buridan should be remembered for more than cruelty to animals - Tony Mann</h4>
     <p>Until very recently I knew very little about the fourteenth-century philosopher John (or Jean) Buridan.  I'm now astonished that nobody told me about his mathematical ideas and I want to share my new enthusiasm.</p>
 	<ul>
-		<li><a href="{{site.url}}/assets/talks/2013/Tony_Mann_-_John_Buridan.pdf">Slides (PDF)</a></li>
-		<li><a href="{{site.url}}/assets/talks/2013/Tony_Mann_-_John_Buridan.pptx">Slides (PPTX)</a></li>
+		<li><a href="{{site.url}}/assets/talks/2013/Tony%20Mann%20-%20John%20Buridan.pdf">Slides (PDF)</a></li>
+		<li><a href="{{site.url}}/assets/talks/2013/Tony%20Mann%20-%20John%20Buridan.pptx">Slides (PPTX)</a></li>
 	</ul>
 </div>
 
@@ -48,7 +48,7 @@ title: MathsJam Gathering 2015
     <h4>An enneahedron for Herschel - Christian Perfect</h4>
     <p>A talk about the funky nine-sided polyhedron I made based on the Herschel graph.</p>
 	<ul>
-		<li><a href="{{site.url}}/assets/talks/2013/Christian_Perfect_-_An_enneahedron_for_Herschel">Slides</a></li>
+		<li><a href="{{site.url}}/assets/talks/2013/Christian%20Perfect%20-%20An%20enneahedron%20for%20Herschel">Slides</a></li>
 		<li><a href="http://aperiodical.com/2013/10/an-enneahedron-for-herschel/">Christian's writeup at The Aperiodical</a></li>
 	</ul>
 </div>
@@ -57,7 +57,7 @@ title: MathsJam Gathering 2015
     <h4>No-one quite knows if we're ripping you off - Adam Atkinson</h4>
     <p>Something from A-level maths (or which plausibly _could_ be in A-level maths even if it isn't in current syllabuses) was useful at work a few years ago, when I needed to compare different tariffs for phone calls.</p>
 	<ul>
-		<li><a href="{{site.url}}/assets/talks/2013/Adam_Atkinson_-_Phonecalls.pdf">Slides (PDF)</a></li>
+		<li><a href="{{site.url}}/assets/talks/2013/Adam%20Atkinson%20-%20Phonecalls.pdf">Slides (PDF)</a></li>
 	</ul>
 </div>
 
@@ -65,8 +65,8 @@ title: MathsJam Gathering 2015
     <h4>Triangle numbers - Phil Harvey</h4>
     <p>I will only refer to a restricted number of interesting facts about triangle numbers. I would also like to make reference to odd socks and high bus numbers. And I would like to attempt a couple of tricks.</p>
     <ul>
-		<li><a href="{{site.url}}/assets/talks/2013/Phil_Harvey_-_Triangle_numbers.pdf">Slides (PDF)</a></li>
-		<li><a href="{{site.url}}/assets/talks/2013/Phil_Harvey_-_Triangle_numbers.ppt">Slides (PPT)</a></li>
+		<li><a href="{{site.url}}/assets/talks/2013/Phil%20Harvey%20-%20Triangle%20numbers.pdf">Slides (PDF)</a></li>
+		<li><a href="{{site.url}}/assets/talks/2013/Phil%20Harvey%20-%20Triangle%20numbers.ppt">Slides (PPT)</a></li>
     </ul>
 </div>
 
@@ -74,8 +74,8 @@ title: MathsJam Gathering 2015
     <h4>The Chris Tarrant Problem - Colin Beveridge</h4>
  	<p>A twist on the Monty Hall problem: should you switch your best guess after going 50-50?</p>
 	<ul>
-	    <li><a href="{{site.url}}/assets/talks/2013/Colin_Beveridge_-_Chris_Tarrant_Problem.pdf">Slides (PDF)</a></li>
-	    <li><a href="{{site.url}}/assets/talks/2013/Colin_Beveridge_-_Chris_Tarrant_Problem.pptx">Slides (PPTX)</a></li>
+	    <li><a href="{{site.url}}/assets/talks/2013/Colin%20Beveridge%20-%20Chris%20Tarrant%20Problem.pdf">Slides (PDF)</a></li>
+	    <li><a href="{{site.url}}/assets/talks/2013/Colin%20Beveridge%20-%20Chris%20Tarrant%20Problem.pptx">Slides (PPTX)</a></li>
 	</ul>
 </div>
 
@@ -90,7 +90,7 @@ title: MathsJam Gathering 2015
     <h4>Betting for the same team - Alistair Bird</h4>
     <p>Many people love to gamble with each other. Unfortunately, sometimes people agree, especially with their friends. Here's one possible way of betting against another person when you both believe in the same outcome.</p>
 	<ul>
-		<li><a href="{{site.url}}/assets/talks/2013/Alistair_Bird_-_Betting_for_the_same_team.pdf">Slides (PDF)</a></li>
+		<li><a href="{{site.url}}/assets/talks/2013/Alistair%20Bird%20-%20Betting%20for%20the%20same%20team.pdf">Slides (PDF)</a></li>
 	</ul>
 </div>
 
@@ -98,8 +98,8 @@ title: MathsJam Gathering 2015
     <h4>Biased coins - Michael Gibson</h4>
     <p>A coin is tossed once and the result is heads.  What is the probability that next time this coin is tossed the result is heads again?  Clearly if the coin is fair, the answer is ½, but what if we know the coin could be biased?</p>
 	<ul>
-	    <li><a href="{{site.url}}/assets/talks/2013/Michael_Gibson_-_Biased_Coins.pdf">Slides (PDF)</a></li>
-	    <li><a href="{{site.url}}/assets/talks/2013/Michael_Gibson_-_Biased_Coins.pptx">Slides (PPTX)</a></li>
+	    <li><a href="{{site.url}}/assets/talks/2013/Michael%20Gibson%20-%20Biased%20Coins.pdf">Slides (PDF)</a></li>
+	    <li><a href="{{site.url}}/assets/talks/2013/Michael%20Gibson%20-%20Biased%20Coins.pptx">Slides (PPTX)</a></li>
 	</ul>
 </div>
 
@@ -107,7 +107,7 @@ title: MathsJam Gathering 2015
     <h4>Chess and mathematics - John Foley</h4>
     <p>The corner attack puzzle combines chess and mathematics. Although outwardly simple and easy to solve, it contains hidden depth. There is a piece in each corner of the board. There is a number in each corner which represents the number of times that the corner is attacked by the pieces in the other corners. The puzzle is to find out what the pieces are.</p>
 	<ul>
-	    <li><a href="{{site.url}}/assets/talks/2013/John_Foley_-_Chess_and_mathematics.pdf">Slides (PDF)</a></li>
+	    <li><a href="{{site.url}}/assets/talks/2013/John%20Foley%20-%20Chess%20and%20mathematics.pdf">Slides (PDF)</a></li>
 	</ul>
 </div>
 
@@ -115,8 +115,8 @@ title: MathsJam Gathering 2015
     <h4>A glance at a couple of maths's weakish links - Ken McKelvie</h4>
     <p>Ken discusses which skills are taught as part of a mathematics course - and which ones should be!</p>
 	<ul>
-	    <li><a href="{{site.url}}/assets/talks/2013/Ken_McKelvie_-_Maths_Weakish_Links.pdf">Slides (PDF)</a></li>
-	    <li><a href="{{site.url}}/assets/talks/2013/Ken_McKelvie_-_Maths_Weakish_Links.pptx">Slides (PPTX)</a></li>
+	    <li><a href="{{site.url}}/assets/talks/2013/Ken%20McKelvie%20-%20Maths%20Weakish%20Links.pdf">Slides (PDF)</a></li>
+	    <li><a href="{{site.url}}/assets/talks/2013/Ken%20McKelvie%20-%20Maths%20Weakish%20Links.pptx">Slides (PPTX)</a></li>
 	</ul>
 </div>
 
@@ -124,8 +124,8 @@ title: MathsJam Gathering 2015
     <h4>The 2½ mile talk - Ewan Leeming</h4>
     <p>The sport of Navigational Rallying is somewhat akin to trying to solve a sudoku on a roller-coaster.  I will introduce it and show how it lends itself to an interesting selection of problem-solving activities for all ages and abilities, and also to activities suitable for Maths and Geography classrooms.</p>
     <ul>
-        <li><a href="{{site.url}}/assets/talks/2013/Ewan_Leeming_-_2.5_mile_talk.pdf">Slides (PDF)</a></li>
-        <li><a href="{{site.url}}/assets/talks/2013/Ewan_Leeming_-_2.5_mile_talk.pptx">Slides (PPTX)</a></li>
+        <li><a href="{{site.url}}/assets/talks/2013/Ewan%20Leeming%20-%202.5%20mile%20talk.pdf">Slides (PDF)</a></li>
+        <li><a href="{{site.url}}/assets/talks/2013/Ewan%20Leeming%20-%202.5%20mile%20talk.pptx">Slides (PPTX)</a></li>
     </ul>
 </div>
 
@@ -133,8 +133,8 @@ title: MathsJam Gathering 2015
     <h4>Some named curves - Yuen Ng</h4>
     <p>Yuen presents some named curves.  They appear in some curious locations, not just on graph paper!</p>
 	<ul>
-	    <li><a href="{{site.url}}/assets/talks/2013/Yuen_Ng_-_Some_named_curves.pdf">Slides (PDF)</a></li>
-	    <li><a href="{{site.url}}/assets/talks/2013/Yuen_Ng_-_Some_named_curves.ppt">Slides (PPT)</a></li>
+	    <li><a href="{{site.url}}/assets/talks/2013/Yuen%20Ng%20-%20Some%20named%20curves.pdf">Slides (PDF)</a></li>
+	    <li><a href="{{site.url}}/assets/talks/2013/Yuen%20Ng%20-%20Some%20named%20curves.ppt">Slides (PPT)</a></li>
 	</ul>
 </div>
 
@@ -142,8 +142,8 @@ title: MathsJam Gathering 2015
     <h4>Excelling at Maths (part 3 of the Egyptian trilogy) - Liz Hind</h4>
     <p>Previously on Maths Jam... So we've seen a couple of examples of great maths from ancient Egypt, but did they excel at maths? Here's another example and some thoughts on what we've learned.</p>
 	<ul>
-    	<li><a href="{{site.url}}/assets/talks/2013/Liz_Hind_-_Excelling_at_maths.pdf">Slides (PDF)</a></li>
-    	<li><a href="{{site.url}}/assets/talks/2013/Liz_Hind_-_Excelling_at_maths.pptx">Slides (PPTX)</a></li>
+    	<li><a href="{{site.url}}/assets/talks/2013/Liz%20Hind%20-%20Excelling%20at%20maths.pdf">Slides (PDF)</a></li>
+    	<li><a href="{{site.url}}/assets/talks/2013/Liz%20Hind%20-%20Excelling%20at%20maths.pptx">Slides (PPTX)</a></li>
 	</ul>
 </div>
 
@@ -158,8 +158,8 @@ title: MathsJam Gathering 2015
     <h4>5 minutes, 3 proofs, no solutions - David Bedford</h4>
     <p></p>
 	<ul>
-	    <li><a href="{{site.url}}/assets/talks/2013/David_Bedford_-_5_minutes.pdf">Slides (PDF)</a></li>
-	    <li><a href="{{site.url}}/assets/talks/2013/David_Bedford_-_5_minutes.pptx">Slides (PPTX)</a></li>
+	    <li><a href="{{site.url}}/assets/talks/2013/David%20Bedford%20-%205%20minutes.pdf">Slides (PDF)</a></li>
+	    <li><a href="{{site.url}}/assets/talks/2013/David%20Bedford%20-%205%20minutes.pptx">Slides (PPTX)</a></li>
 	</ul>
 </div>
 
@@ -167,8 +167,8 @@ title: MathsJam Gathering 2015
     <h4>Fun with 2D glasses - Michael Gibson</h4>
     <p>2D glasses, yes you read correctly, 2D glasses - not 3D glasses, which are very old-hat.  2D glasses are easy to make by cutting pairs of 3D glasses in half and joining together pieces of the same colour.  By making graph paper with 2 different types of scale, each printed in a different colour, it is possible to plot some data just once, but view it from 2 different points of view, depending on what colour glasses you view it through.</p>
 	<ul>
-    	<li><a href="{{site.url}}/assets/talks/2013/Michael_Gibson_-_Fun_with_2D_Glasses.pdf">Slides (PDF)</a></li>
-    	<li><a href="{{site.url}}/assets/talks/2013/Michael_Gibson_-_Fun_with_2D_Glasses.pptx">Slides (PPTX)</a></li>
+    	<li><a href="{{site.url}}/assets/talks/2013/Michael%20Gibson%20-%20Fun%20with%202D%20Glasses.pdf">Slides (PDF)</a></li>
+    	<li><a href="{{site.url}}/assets/talks/2013/Michael%20Gibson%20-%20Fun%20with%202D%20Glasses.pptx">Slides (PPTX)</a></li>
 	</ul>
 </div>
 
@@ -191,8 +191,8 @@ title: MathsJam Gathering 2015
     <h4>Dual inversal numbers - Katie Steckles</h4>
     <p>An interesting property of certain numbers, which was described to me by a mathematician I once met, and my response to his initial findings.</p>
 	<ul>
-		<li><a href="{{site.url}}/assets/talks/2013/Katie_Steckles_-_Dual_Inversal_numbers.pdf">Slides (PDF)</a></li>
-		<li><a href="{{site.url}}/assets/talks/2013/Katie_Steckles_-_Dual_Inversal_numbers.pptx">Slides (PPTX)</a></li>
+		<li><a href="{{site.url}}/assets/talks/2013/Katie%20Steckles%20-%20Dual%20Inversal%20numbers.pdf">Slides (PDF)</a></li>
+		<li><a href="{{site.url}}/assets/talks/2013/Katie%20Steckles%20-%20Dual%20Inversal%20numbers.pptx">Slides (PPTX)</a></li>
 		<li><a href="http://aperiodical.com/2013/11/from-the-mailbag-dual-inversal-numbers/">Katie's Writeup at The Aperiodical</a></li>
 	</ul>
 </div>
@@ -201,8 +201,8 @@ title: MathsJam Gathering 2015
     <h4>Here be dragons - Pat Ashforth &amp; Steve Plummer</h4>
     <p>A crafty look at dragon curves.</p>
 	<ul>
-		<li><a href="{{site.url}}/assets/talks/2013/Steve_Plummer_-_Here_be_dragons.pdf">Slides (PDF)</a></li>
-		<li><a href="{{site.url}}/assets/talks/2013/Steve_Plummer_-_Here_be_dragons.pptx">Slides (PPTX)</a></li>
+		<li><a href="{{site.url}}/assets/talks/2013/Steve%20Plummer%20-%20Here%20be%20dragons.pdf">Slides (PDF)</a></li>
+		<li><a href="{{site.url}}/assets/talks/2013/Steve%20Plummer%20-%20Here%20be%20dragons.pptx">Slides (PPTX)</a></li>
 	</ul>
 </div>
 
@@ -215,9 +215,9 @@ title: MathsJam Gathering 2015
     <h4>Matt almost understands Bitcoin - Matt Parker</h4>
     <p>Bitcoin is a cryptocurrency. Or is a cryptocommodity? Either way it involves computers. And a lot of maths. Matt Parker will try to explain that maths. He may get some of it wrong.</p>
 	<ul>
-		<li><a href="{{site.url}}/assets/talks/2013/Matt_Parker_-_Bitcoin.pdf">Slides (PDF)</a></li>
-		<li><a href="{{site.url}}/assets/talks/2013/Matt_Parker_-_Bitcoin.ppt">Slides (PPT)</a></li>
-		<li><a href="{{site.url}}/assets/talks/2013/Matt_Parker_-_Bitcoin.key">Slides (Keynote)</a></li>
+		<li><a href="{{site.url}}/assets/talks/2013/Matt%20Parker%20-%20Bitcoin.pdf">Slides (PDF)</a></li>
+		<li><a href="{{site.url}}/assets/talks/2013/Matt%20Parker%20-%20Bitcoin.ppt">Slides (PPT)</a></li>
+		<li><a href="{{site.url}}/assets/talks/2013/Matt%20Parker%20-%20Bitcoin.key">Slides (Keynote)</a></li>
 	</ul>
 </div>
 
@@ -254,8 +254,8 @@ title: MathsJam Gathering 2015
     <h4>Developing mathematical creativity - Alison Kiddle</h4>
     <p>In my day job working for NRICH, I am currently working on a project looking at developing school students' mathematical creativity. I'd love to share a little bit about the project, and find out if any MathsJammers can help!</p>
 	<ul>
-		<li><a href="{{site.url}}/assets/talks/2013/Alison_Kiddle_-_Creativity.pdf">Slides (PDF)</a></li>
-		<li><a href="{{site.url}}/assets/talks/2013/Alison_Kiddle_-_Creativity.ppt">Slides (PPT)</a></li>
+		<li><a href="{{site.url}}/assets/talks/2013/Alison%20Kiddle%20-%20Creativity.pdf">Slides (PDF)</a></li>
+		<li><a href="{{site.url}}/assets/talks/2013/Alison%20Kiddle%20-%20Creativity.ppt">Slides (PPT)</a></li>
 	</ul>
 </div>
 
@@ -263,7 +263,7 @@ title: MathsJam Gathering 2015
     <h4>Hyperbolic knots - Nicholas Jackson</h4>
     <p>There are three types of two-dimensional geometry: Euclidean, spherical and hyperbolic. In three dimensions there are eight.  The (three-dimensional) space around a knot has a canonical geometry - in almost all cases this is hyperbolic, and tells us useful information about the knot.</p>
 	<ul>
-		<li><a href="{{site.url}}/assets/talks/2013/Nicholas_Jackson_-_Hyperbolic_Knots.pdf">Slides (PDF)</a></li>
+		<li><a href="{{site.url}}/assets/talks/2013/Nicholas%20Jackson%20-%20Hyperbolic%20Knots.pdf">Slides (PDF)</a></li>
 	</ul>
 </div>
 
@@ -271,7 +271,7 @@ title: MathsJam Gathering 2015
     <h4>Perfect squared Klein bottle myths - Geoffrey Morley</h4>
 	<p>A minimum of nine unequal squares is needed to tile a rectangle. I shall show how surprisingly few unequal squares can tile a M�bius band or Klein bottle and debunk a few myths.</p>
 	<ul>
-		<li><a href="{{site.url}}/assets/talks/2013/Geoffrey_Morley_-_Klein_Squarings.pdf">Slides (PDF)</a></li>
+		<li><a href="{{site.url}}/assets/talks/2013/Geoffrey%20Morley%20-%20Klein%20Squarings.pdf">Slides (PDF)</a></li>
 	</ul>
 </div>
 
@@ -296,8 +296,8 @@ title: MathsJam Gathering 2015
     <h4>one three hundred and eighty fourth (1/384) - John David Read</h4>
     <p>A derivative tweet led to thinking more deeply about an interesting pattern in structural mechanics that it turns out also occurs in another area of maths.</p>
 	<ul>
-		<li><a href="{{site.url}}/assets/talks/2013/John_Read_-_1_over_384.pdf">Slides (PDF)</a></li>
-		<li><a href="{{site.url}}/assets/talks/2013/John_Read_-_1_over_384.pptx">Slides (PPTX)</a></li>
+		<li><a href="{{site.url}}/assets/talks/2013/John%20Read%20-%201%20over%20384.pdf">Slides (PDF)</a></li>
+		<li><a href="{{site.url}}/assets/talks/2013/John%20Read%20-%201%20over%20384.pptx">Slides (PPTX)</a></li>
 	</ul>
 </div>
 
@@ -310,7 +310,7 @@ title: MathsJam Gathering 2015
     <h4>Ox Blocks probabilities - Peter Rowlett</h4>
     <p>I will talk through what the Ox Blocks game is and how it is played, and an investigation I did of the unusual dice that are involved.</p>
 	<ul>
-    <li><a href="{{site.url}}/assets/talks/2013/Peter_Rowlett_-_Ox_Blocks_probabilities.pdf">Slides (PDF)</a></li>
+    <li><a href="{{site.url}}/assets/talks/2013/Peter%20Rowlett%20-%20Ox%20Blocks%20probabilities.pdf">Slides (PDF)</a></li>
 	</ul>
 </div>
 
@@ -318,8 +318,8 @@ title: MathsJam Gathering 2015
     <h4>"There are two X, but at least one is Y" - Rob Eastaway</h4>
     <p>The problem with so-called probability questions like the "Tuesday Boy Problem", and indeed "The Thursday Girl Problem" is that they depend on who poses the problem. I've been investigating who it is that says things like "I have two of X, one of which is a Y."</p>
 	<ul>
-    <li><a href="{{site.url}}/assets/talks/2013/Rob_Eastaway_-_Tuesday_boy.pdf">Slides (PDF)</a></li>
-    <li><a href="{{site.url}}/assets/talks/2013/Rob_Eastaway_-_Tuesday_boy.ppt">Slides (PPT)</a></li>
+    <li><a href="{{site.url}}/assets/talks/2013/Rob%20Eastaway%20-%20Tuesday%20boy.pdf">Slides (PDF)</a></li>
+    <li><a href="{{site.url}}/assets/talks/2013/Rob%20Eastaway%20-%20Tuesday%20boy.ppt">Slides (PPT)</a></li>
 	</ul>
 </div>
 
@@ -337,7 +337,7 @@ title: MathsJam Gathering 2015
     <h4>Ying-yang theorem - Emma McCaughan</h4>
     <p>Emma examines puzzle 15 from this set, and presents a theorem.</p>
 	<ul>
-		<li><a href="{{site.url}}/assets/talks/2013/Emma_McCaughan_-_Ying-Yang.pdf">Slides (PDF)</a></li>
+		<li><a href="{{site.url}}/assets/talks/2013/Emma%20McCaughan%20-%20Ying-Yang.pdf">Slides (PDF)</a></li>
 	</ul>
 </div>
 
@@ -360,7 +360,7 @@ title: MathsJam Gathering 2015
     <h4>Tescoefficient - Joel Hadley</h4>
     <p>Joel calculates the density of Tesco stores in a given city.</p>
     <ul>
-		<li><a href="{{site.url}}/assets/talks/2013/Joel_Hadley_-_Tescoefficient.pdf">Slides (PDF)</a></li>
+		<li><a href="{{site.url}}/assets/talks/2013/Joel%20Hadley%20-%20Tescoefficient.pdf">Slides (PDF)</a></li>
 	</ul>
 </div>
 
@@ -377,8 +377,8 @@ title: MathsJam Gathering 2015
     <h4>Saros and Inex - Mike Frost</h4>
     <p>On the pseudo-periodicities of solar eclipses.</p>
 	<ul>
-    <li><a href="{{site.url}}/assets/talks/2013/Mike_Frost_-_Total_eclipses.pdf">Slides (PDF)</a></li>
-    <li><a href="{{site.url}}/assets/talks/2013/Mike_Frost_-_Total_eclipses.ppt">Slides (PPT)</a></li>
+    <li><a href="{{site.url}}/assets/talks/2013/Mike%20Frost%20-%20Total%20eclipses.pdf">Slides (PDF)</a></li>
+    <li><a href="{{site.url}}/assets/talks/2013/Mike%20Frost%20-%20Total%20eclipses.ppt">Slides (PPT)</a></li>
 	</ul>
 </div>
 
@@ -386,8 +386,8 @@ title: MathsJam Gathering 2015
 	<h4>Proof that root 2 is irrational - Francis Hunt</h4>
     <p>By folding a square piece of paper, I will prove that the square root of 2 is irrational.</p>
 	<ul>
-		<li><a href="{{site.url}}/assets/talks/2013/Francis_Hunt_-_Root_2.pdf">Slides (PDF)</a></li>
-		<li><a href="{{site.url}}/assets/talks/2013/Francis_Hunt_-_Root_2.pptx">Slides (PPTX)</a></li>
+		<li><a href="{{site.url}}/assets/talks/2013/Francis%20Hunt%20-%20Root%202.pdf">Slides (PDF)</a></li>
+		<li><a href="{{site.url}}/assets/talks/2013/Francis%20Hunt%20-%20Root%202.pptx">Slides (PPTX)</a></li>
 	</ul>
 </div>
 
@@ -400,7 +400,7 @@ title: MathsJam Gathering 2015
     <h4>Centrifugal force at the bottom of a tuning fork makes a noise at double the frequency - Hugh Hunt</h4>
     <p>If the prongs vibrate symmetrically then the handle is a node.</p>
 	<ul>
-    <li><a href="{{site.url}}/assets/talks/2013/Hugh_Hunt_-_Tuning_fork.pdf">Slides (PDF)</a></li>
-    <li><a href="{{site.url}}/assets/talks/2013/Hugh_Hunt_-_Tuning_fork.pptx">Slides (PPTX)</a></li>
+    <li><a href="{{site.url}}/assets/talks/2013/Hugh%20Hunt%20-%20Tuning%20fork.pdf">Slides (PDF)</a></li>
+    <li><a href="{{site.url}}/assets/talks/2013/Hugh%20Hunt%20-%20Tuning%20fork.pptx">Slides (PPTX)</a></li>
 	</ul>
 </div>

--- a/gathering/archive/2015/index.html
+++ b/gathering/archive/2015/index.html
@@ -349,7 +349,7 @@ title: MathsJam Gathering 2015
     <h4>3D Printing From The Inside Out - Dan Hagon</h4>
         <p>Some mesh shapes are possible to 3D print, and others are not. Dan uses a bit of topology to figure out which.</p>
    <ul>
-        <li><a href="{{site.url}}/assets/talks/2015/DanHagon-3Dprinting.pdf">Slides (PDF)</a></li>
+        <li><a href="{{site.url}}/assets/talks/2015/DanHagon-3DPrinting.pdf">Slides (PDF)</a></li>
      
     </ul>
 </div>

--- a/gathering/archive/2016/index.html
+++ b/gathering/archive/2016/index.html
@@ -1,3 +1,4 @@
+---
 layout: gathering
 title: MathsJam Gathering 2016
 ---

--- a/gathering/archive/2016/index.html
+++ b/gathering/archive/2016/index.html
@@ -1,4 +1,3 @@
----
 layout: gathering
 title: MathsJam Gathering 2016
 ---
@@ -147,8 +146,8 @@ title: MathsJam Gathering 2016
 	<h4>Sam Headleand - Mathematics of matrimony</h4>
     <p>Description</p>
     <ul>
-        <li><a href="{{site.url}}/assets/talks/2016/SamHeadleand-MathematicsOfMatrimony.pptx">Slides (PPTX)</a></li>
-	<li><a href="{{site.url}}/assets/talks/2016/SamHeadleand-MathematicsOfMatrimony.pdf">Slides (PDF)</a></li>
+        <li><a href="{{site.url}}/assets/talks/2016/SamHeadleand-MathematicsofMatrimony.pptx">Slides (PPTX)</a></li>
+        <li><a href="{{site.url}}/assets/talks/2016/SamHeadleand-MathematicsofMatrimony.pdf">Slides (PDF)</a></li>
     </ul>
 </div>
 <div class="talk">


### PR DESCRIPTION
It seems the entire 2013 archive had spaces swapped with underscores, and a couple of 2015/2016 talks had case-sensitivity issues.