### PR TITLE
Martin's first GitHub change!

### DIFF
--- a/gathering/talks.md
+++ b/gathering/talks.md
@@ -43,7 +43,7 @@ This list is subject to some small changes, but keep checking here for the most 
 - Alison Clarke: Stupid Units
 - Belgin Seymenoglu: Donald in Mathmagic Land
 - Douglas Buchanan: Lowering the Tone
-- David Mitchell: The Thereom of Trythagoras (Pythagoras is for Squares)
+- David Mitchell: The Theorem of Trythagoras (Pythagoras is for Squares)
 - Dave Gale: Catchphrase and Coffee
 
 ### Sunday


### PR DESCRIPTION
My mum spotted a typo in the name of David Mitchell's talk when I was showing her the programme of talks, so I have corrected it as a test of me using GitHub.
Also, I notice that Matt Peperell's talk has the word 'deducation' in it - I thought I'd mention this within this comment because I'm not sure whether it's meant to be 'deduction', 'education', or a deliberate portmanteau of the two.