### PR TITLE
Update Cardiff's page (help needed thank you)

### DIFF
--- a/cities/cardiff.md
+++ b/cities/cardiff.md
@@ -18,4 +18,5 @@ location:
 hiatus: False
 hiatus_months:
     - 2017-08
+    - 2018-01
 ---


### PR DESCRIPTION
Cardiff's MathsJam won't meet for January 2018 because a variety of circumstances. We will meet in February as usual. I'm not sure I've set up the hiatus correctly above. Thank you for assisting. Elizabeth