### PR TITLE
Update auckland.md

### DIFF
--- a/cities/auckland.md
+++ b/cities/auckland.md
@@ -1,6 +1,6 @@
 ---
 layout: city                                           
-city_name: Auckland, NZ                                                               
+city_name: Auckland                                                               
 jam_name: Auckland MathsJam
 email: auckland@mathsjam.com
 twitter: AKLMathsJam


### PR DESCRIPTION
removing ", Countryname" from various cities because the "rest of world" page is strangely inconsistent. It seems like switching to all without country name makes sense. If you don't know which country Pavia is in you're not likely to be going to its Jam any time soon.