### PR TITLE
Update December date

### DIFF
--- a/cities/turin.md
+++ b/cities/turin.md
@@ -16,5 +16,5 @@ location:
     lat: 45.0541234
 hiatus: False
 changed_dates:
-    - 2018-07-26
+    - 2018-11-19
 ---

--- a/cities/turin.md
+++ b/cities/turin.md
@@ -16,5 +16,5 @@ location:
     lat: 45.0541234
 hiatus: False
 changed_dates:
-    - 2018-11-19
+    - 2018-12-19
 ---


### PR DESCRIPTION
Next Turin MathsJam will happen on Wed 19 Dec 2018. :) 