### PR TITLE
Update index.md

### DIFF
--- a/gathering/uk/archive/2019/index.md
+++ b/gathering/uk/archive/2019/index.md
@@ -42,22 +42,19 @@ An unexpected problem of patternmaking, and the even more unexpected use of that
 #### Adam Atkinson: Roman Mathematics
 Some countries are unmixed - mixed numbers don't exist, or are perceived not to exist. Adam talked about Italy as a specific example since he knows it better than the others he has heard of (France, Spain, Portugal). The talk was partly about unmixedness but mostly about how hard it is to investigate this kind of issue. If you work with people from overseas it could be useful to know that some of them may never have seen mixed numbers before.
 
- - [Adam's slides (PPT)]({{site.url}}/assets/talks/2019/AdamAtkinson-RomanMathematics.pptx)
  - [Adam's slides (PDF)]({{site.url}}/assets/talks/2019/AdamAtkinson-RomanMathematics.pdf)
  - [The 2018 article Adam referred to](http://maddmaths.simai.eu/divulgazione/langolo-arguto/matematica-il-linguaggio-universale/); [some of the reactions](https://www.facebook.com/alberto.saracco.73/posts/10156001424164538), and [some other reactions](https://www.facebook.com/maddmathspage/photos/gm.1946060578770890/2283512685267878/?type=3&theater)
 
 #### Geoff Morley: Neosemimagic Tilings
 A generalisation of both semimagic squares and perfect squared squares brings new challenges.
 
- - [Geoff's slides (PPT)]({{site.url}}/assets/talks/2019/GeoffMorley-NeosemimagicTilings.pptx)
- - [Geoff's slides (PDF)]({{site.url}}/assets/talks/2019/GeoffMorley-NeosemimagicTilings.pdf)
+  - [Geoff's slides (PDF)]({{site.url}}/assets/talks/2019/GeoffMorley-NeosemimagicTilings.pdf)
 
 #### Laurence O'Toole: Predicting Groupthink - A Magic Trick
 Make a prediction, and deal out several number cards to the audience. Then play a simple 2-rule game, where people take turns in picking one of the remaining numbers. Afterwards, all of the choices match the original prediction in a nice way.
 
 (I'm not sure if I'm explaining this terribly well. But I don't want to just explicitly write out the details of every single step of the trick. I have no objections if anybody wants to rewrite the above paragraph after the fact.)
 
- - [Laurence's slides (PPT)]({{site.url}}/assets/talks/2019/LaurenceO'Toole-PredictingGroupthink-AMagicTrick.pptx)
  - [Laurence's slides (PDF)]({{site.url}}/assets/talks/2019/LaurenceO'Toole-PredictingGroupthink-AMagicTrick.pdf)
 
 ### SESSION 1b
@@ -65,14 +62,10 @@ Make a prediction, and deal out several number cards to the audience. Then play 
 #### Peter Rowlett: &#35;tmwyk
 &#35;tmwyk is a Twitter hashtag used to share mathematical conversations with children. I will share some examples of mathematical chat I’ve had with my four-year-old and touch briefly on play in mathematical education.
 
- - [Peter's slides (PPT)]({{site.url}}/assets/talks/2019/PeterRowlett-#tmwyk.pptx)
  - [Peter's slides (PDF)]({{site.url}}/assets/talks/2019/PeterRowlett-#tmwyk.pdf)
 
 #### Tony Mann: A curious magic square trick
 I recently came across this interesting variation of the I will construct a magic square for a given target sum trick, due to Andi Gladwin and published as [https://www.youtube.com/watch?v=nHoZ1l3YVcg](Magic Squared).
-
- - [Tony's slides (PPT)]({{site.url}}/assets/talks/2019/TonyMann-Acuriousmagicsquaretrick.pptx)
- - [Tony's slides (PDF)]({{site.url}}/assets/talks/2019/TonyMann-Acuriousmagicsquaretrick.pdf)
 
 #### Mark Fisher: Mersenne and Cole 
 Cole found the factors of 2^67 - 1, after Mersenne had claimed it was prime
@@ -83,8 +76,8 @@ Cole found the factors of 2^67 - 1, after Mersenne had claimed it was prime
 #### Eva Lesny: How many are in a few?
 What do 'a few', 'a handful', and 'almost' mean to you? Ever wondered if they mean the same to others?https://public.tableau.com/profile/fenneklyra#!/vizhome/Howmanyareinafew/Thecrowd
 
- - [Eva's slides (PPT)]({{site.url}}/assets/talks/2019/EvaLesny-Howmanyareinafew?.pptx)
- - [Eva's slides (PDF)]({{site.url}}/assets/talks/2019/EvaLesny-Howmanyareinafew?.pdf)
+ - [Eva's slides (PPT)]({{site.url}}/assets/talks/2019/EvaLesny-Howmanyareinafew.pptx)
+ - [Eva's slides (PDF)]({{site.url}}/assets/talks/2019/EvaLesny-Howmanyareinafew.pdf)
 
 #### David Mitchell: The Brothers Fibonacci; Etiam mingens mathematicae memini!
 Shyness in the gents pointed Fibonacci to his celebrated discovery. Even greater shyness leads to a generalisation of his sequence and of the algebraically expressible Golden Ratio to which the ratio of successive numbers converges. (Thanks to Nottingham MathsJam attendees for illuminating observations)
@@ -107,27 +100,25 @@ Starting with a unit square of paper, how can we fold it to divide a side into a
 #### James Grime: S.O.X.
 James presents one of his favourite mathematical books - and he's written his own version and gives everyone a copy!
 
- - [James's slides (PPT)]({{site.url}}/assets/talks/2019/JamesGrime-S.O.X..pptx)
- - [James's slides (PDF)]({{site.url}}/assets/talks/2019/JamesGrime-S.O.X..pdf)
+ - [James's slides (PPT)]({{site.url}}/assets/talks/2019/JamesGrime-SOX.pptx)
+ - [James's slides (PDF)]({{site.url}}/assets/talks/2019/JamesGrime-SOX.pdf)
 
 ### SESSION 1c
 
 #### Tom Button: Is the mathematical mind flat?
 Do we solve mathematical problems subconsciously or is this just a myth?
 
- - [Tom's slides (PPT)]({{site.url}}/assets/talks/2019/TomButton-Isthemathematicalmindflat?.pptx)
- - [Tom's slides (PDF)]({{site.url}}/assets/talks/2019/TomButton-Isthemathematicalmindflat?.pdf)
+ - [Tom's slides (PPT)]({{site.url}}/assets/talks/2019/TomButton-Isthemathematicalmindflat.pptx)
+ - [Tom's slides (PDF)]({{site.url}}/assets/talks/2019/TomButton-Isthemathematicalmindflat.pdf)
 
 #### Sam Hartburn: (Not) Squaring the Circle
 A poetic (well, rhyming (well, mostly)) look at some shapes that can be squared using ruler and compass.
 
- - [Sam's slides (PPT)]({{site.url}}/assets/talks/2019/SamHartburn-(Not)SquaringtheCircle.pptx)
- - [Sam's slides (PDF)]({{site.url}}/assets/talks/2019/SamHartburn-(Not)SquaringtheCircle.pdf)
+ - [Reading and text of Sam's poem](https://samhartburn.co.uk/sh/not-squaring-the-circle/)
 
 #### Alexander Bolton: Factor Graphs and Unsupervised Joke Generation
 I will introduce the concept of factor graphs and describe an application of them to joke generation.
 
- - [Alexander's slides (PPT)]({{site.url}}/assets/talks/2019/AlexanderBolton-FactorGraphsandUnsupervisedJokeGeneration.pptx)
  - [Alexander's slides (PDF)]({{site.url}}/assets/talks/2019/AlexanderBolton-FactorGraphsandUnsupervisedJokeGeneration.pdf)
 
 #### Jonathan Welton: Domino Knights and Patios
@@ -139,26 +130,19 @@ If chess pieces were domino sized, what move would the knight have? And what boa
 #### Martin Chlond: The Travelling Salesman Problem: A couple of whimsical applications (Part 2)
 Completion of last years talk.
 
- - [Martin's slides (PPT)]({{site.url}}/assets/talks/2019/MartinChlond-TheTravellingSalesmanProblem:Acoupleofwhimsicalapplications(Part2).pptx)
- - [Martin's slides (PDF)]({{site.url}}/assets/talks/2019/MartinChlond-TheTravellingSalesmanProblem:Acoupleofwhimsicalapplications(Part2).pdf)
+ - [Martin's slides (PPT)]({{site.url}}/assets/talks/2019/MartinChlond-TheTravellingSalesmanProblemAcoupleofwhimsicalapplications(Part2).pptx)
+ - [Martin's slides (PDF)]({{site.url}}/assets/talks/2019/MartinChlond-TheTravellingSalesmanProblemAcoupleofwhimsicalapplications(Part2).pdf)
 
 #### Alistair Bird: The Bottle Imp
 The Robert Louis Stevenson short story The Bottle Imp has an unusually mathematical set-up, with an inductive quandary like the 'unexpected hanging' or 'surprise exam' paradox. We also talk about a card game based on the story, and discuss how to behave before an apocalypse.
 
- - [Alistair's slides (PPT)]({{site.url}}/assets/talks/2019/AlistairBird-TheBottleImp.pptx)
  - [Alistair's slides (PDF)]({{site.url}}/assets/talks/2019/AlistairBird-TheBottleImp.pdf)
 
 #### Karen Hancock: How many ways to turn a corner?
 Thoughts on the many variations of a sock heel.
 
- - [Karen's slides (PPT)]({{site.url}}/assets/talks/2019/KarenHancock-Howmanywaystoturnacorner?.pptx)
- - [Karen's slides (PDF)]({{site.url}}/assets/talks/2019/KarenHancock-Howmanywaystoturnacorner?.pdf)
-
 #### Yuen Ng: Moving on from Napier's bones...
 A brief demo of some Genaille-Lucas rulers - does bigger always mean better?
-
- - [Yuen's slides (PPT)]({{site.url}}/assets/talks/2019/YuenNg-MovingonfromNapier'sbones....pptx)
- - [Yuen's slides (PDF)]({{site.url}}/assets/talks/2019/YuenNg-MovingonfromNapier'sbones....pdf)
 
 ### SESSION 1d
 
@@ -177,8 +161,10 @@ A very brief introduction to Escher's work and the permanent exhibition in The H
 #### Gavan Fantom: What if numbers could have negative digits?
 Imagine if individual digits within a number could be either positive or negative. Could you use small negative digits instead of large positive ones? Could you avoid learning your times tables past five? Join me for a brief introduction to a fascinating approach to arithmetic.
 
- - [Gavan's slides (PPT)]({{site.url}}/assets/talks/2019/GavanFantom-Whatifnumberscouldhavenegativedigits?.pptx)
- - [Gavan's slides (PDF)]({{site.url}}/assets/talks/2019/GavanFantom-Whatifnumberscouldhavenegativedigits?.pdf)
+ - [Gavan's slides (4x3) (PPT)]({{site.url}}/assets/talks/2019/GavanFantom-Whatifnumberscouldhavenegativedigits_4x3.odp)
+ - [Gavan's slides (4x3) (PDF)]({{site.url}}/assets/talks/2019/GavanFantom-Whatifnumberscouldhavenegativedigits_4x3.pdf)
+ - [Gavan's slides (16x9) (PPT)]({{site.url}}/assets/talks/2019/GavanFantom-Whatifnumberscouldhavenegativedigits_16x9.odp)
+ - [Gavan's slides (16x9) (PDF)]({{site.url}}/assets/talks/2019/GavanFantom-Whatifnumberscouldhavenegativedigits_16x9.pdf)
 
 #### Martin Whitworth: Sums of powers
 I guess most Mathsjammers know the formula for sums of consecutive integers, and many may know the one for sums of squares, but what about higher powers? - and how is Pascal's triangle involved?
@@ -197,13 +183,9 @@ Discussion on several Subtraction techniques, including 'borrowing and paying ba
 #### Colin Wright: 70 vs 100
 We all know that if you're travelling faster it takes longer to stop, and we think we know the rules.  But do we?
 
- - [Colin's slides (PPT)]({{site.url}}/assets/talks/2019/ColinWright-70vs100.pptx)
- - [Colin's slides (PDF)]({{site.url}}/assets/talks/2019/ColinWright-70vs100.pdf)
-
 #### Matthew Scroggs: Why and how I wrote a LaTeX package
 In early 2019, I wrote the realhats LaTeX package with Adam Townsend. This package redefines \hat to put a picture of an actual hat on a symbol instead of a ^ hat. Because why not.
 
- - [Matthew's slides (PPT)]({{site.url}}/assets/talks/2019/MatthewScroggs-WhyandhowIwroteaLaTeXpackage.pptx)
  - [Matthew's slides (PDF)]({{site.url}}/assets/talks/2019/MatthewScroggs-WhyandhowIwroteaLaTeXpackage.pdf)
 
 #### Pat Ashforth: Using maths without knowing it
@@ -221,7 +203,6 @@ It's not just pentagons and fibonacci
 #### Isabel Coelho: The Mirror Reversal Problem
 I look  in the mirror. My reflection looks back at me. When I wave  my right hand, my image waves her left. When I wave  my left hand, my image waves her right. Why do mirrors reversal left and right? And, if right becomes left and left becomes right, why does not top become bottom?
 
- - [Isabel's slides (PPT)]({{site.url}}/assets/talks/2019/IsabelCoelho-TheMirrorReversalProblem.pptx)
  - [Isabel's slides (PDF)]({{site.url}}/assets/talks/2019/IsabelCoelho-TheMirrorReversalProblem.pdf)
 
 ### SESSION 2b
@@ -229,27 +210,24 @@ I look  in the mirror. My reflection looks back at me. When I wave  my right han
 #### Hugh Hunt: Four possibilities:
 With a beautiful - and musical - demo, and how this helps if you have a noisy washing machine
 
- - [Hugh's slides (PPT)]({{site.url}}/assets/talks/2019/HughHunt-Fourpossibilities:.pptx)
- - [Hugh's slides (PDF)]({{site.url}}/assets/talks/2019/HughHunt-Fourpossibilities:.pdf)
+ - [Hugh's slides (PPT)]({{site.url}}/assets/talks/2019/HughHunt-Fourpossibilities.ppt)
+ - [Hugh's slides (PDF)]({{site.url}}/assets/talks/2019/HughHunt-Fourpossibilities.pdf)
 
 #### Alison Eves: Florence Nightingale: the compassionate statistician
 2020 is the bicentenary of Florence's birth: a great opportunity to celebrate her contribution to statistics, and their use in saving lives!
 
- - [Alison's slides (PPT)]({{site.url}}/assets/talks/2019/AlisonEves-FlorenceNightingale:thecompassionatestatistician.pptx)
- - [Alison's slides (PDF)]({{site.url}}/assets/talks/2019/AlisonEves-FlorenceNightingale:thecompassionatestatistician.pdf)
+ - [Alison's slides (PPT)]({{site.url}}/assets/talks/2019/AlisonEves-FlorenceNightingalethecompassionatestatistician.pptx)
+ - [Alison's slides (PDF)]({{site.url}}/assets/talks/2019/AlisonEves-FlorenceNightingalethecompassionatestatistician.pdf)
 
 #### Andrew Taylor: The Belt Trick Spinor
 I saw a GIF of this lovely belt trick spinor on Twitter and wanted to understand it, so I built my own version https://www.shadertoy.com/view/3t2Xzy
 
 What's actually happening is that the central cube is always drawn upside-down, but the *axis it's rotated about* is spinning. The rotated cube in the final scene spins twice as fast as the axis — but once the axis has rotated 180º and the cube is back where it started, the space around it (and therefore the connecting belts) is stuck interpolating the other way. You need to rotate the axis another 180º to reset the whole scene, and that's where the 720º periodicity comes from.
 
- - [Andrew's slides (PPT)]({{site.url}}/assets/talks/2019/AndrewTaylor-TheBeltTrickSpinor.pptx)
- - [Andrew's slides (PDF)]({{site.url}}/assets/talks/2019/AndrewTaylor-TheBeltTrickSpinor.pdf)
-
 #### Christian Lawson-Perfect: Baked Sudoku
 You can impose on Sudoku puzzles a physical system which works surprisingly well. It has phase transitions, and when you reduce the heat it settles into a solved state!
 
- - [Christian's slides (PPT)]({{site.url}}/assets/talks/2019/ChristianLawson-Perfect-BakedSudoku.pptx)
+ - [Christian's slides (PPT)](http://somethingorotherwhatever.com/baked-sudoku-big-mathsjam-2019/)
  - [Christian's slides (PDF)]({{site.url}}/assets/talks/2019/ChristianLawson-Perfect-BakedSudoku.pdf)
 
 #### Miguel Gonçalves: From a new deck to Si Stebbins 
@@ -263,8 +241,7 @@ Last year I started an in-depth course on Jazz Harmony. A lot of new concept for
 Even if my teacher, and impressive pianist, told me I was making my life more difficult, I needed to create my own version of the musical staff, in order to use simple Maths instead keep memorizing notes positions and combination. 
 I call it 'super-penta' (the staff is called  'pentagramma' in Italian) and you can use it too! 
 
- - [Stefania's slides (PPT)]({{site.url}}/assets/talks/2019/StefaniaDelprete-Whythemusicstaffisnotreallymathematicallycorrect?.pptx)
- - [Stefania's slides (PDF)]({{site.url}}/assets/talks/2019/StefaniaDelprete-Whythemusicstaffisnotreallymathematicallycorrect?.pdf)
+ - [Stefania's slides (PDF)]({{site.url}}/assets/talks/2019/StefaniaDelprete-Whythemusicstaffisnotreallymathematicallycorrect.pdf)
 
 ### SESSION 2c
 
@@ -277,7 +254,7 @@ Deux Nuts is a tricky bolt with two captive nuts that mysteriously twist opposit
 #### Sydney Weaver: Permutations of the Cube
 Discussing approaches to calculating the permutations of a rubik's cube and other twisty puzzles. 
 
- - [Sydney's slides (PPT)]({{site.url}}/assets/talks/2019/SydneyWeaver-PermutationsoftheCube.pptx)
+ - [Sydney's slides (PPT)](https://docs.google.com/presentation/d/1c8lfc9YGqhFFYuQUThwajjJ2tcHt91WOjb6YerPQrtk/edit?usp=sharing)
  - [Sydney's slides (PDF)]({{site.url}}/assets/talks/2019/SydneyWeaver-PermutationsoftheCube.pdf)
 
 #### Miles Gould: Quantum computing in perspective
@@ -289,15 +266,12 @@ In quantum computers, the state of a qubit (quantum bit) can be something in-bet
 #### Zoe Griffiths : Two thousand and nineteen
 Zoe performs a mathematical trick that she designed after reminiscing about key mathematical events of the year 2019. Watch this video by Zoe to find out how she did her magic trick: https://zoelgriffiths.co.uk/index.php/2019/11/29/binary-memory-tricks/
 
- - [Zoe's slides (PPT)]({{site.url}}/assets/talks/2019/ZoeGriffiths-Twothousandandnineteen.pptx)
- - [Zoe's slides (PDF)]({{site.url}}/assets/talks/2019/ZoeGriffiths-Twothousandandnineteen.pdf)
-
 #### Luna Kirkby: Cursed Regular Expressions
 We explore the equivalence between regular expressions and finite state machines, and discuss how to reduce any FSM into a regex, culminating in some truly cursed behemoth regular expressions based on sokoban, peg solitaire, and even juggling.
 
- - [Luna's slides (PPT)]({{site.url}}/assets/talks/2019/LunaKirkby-CursedRegularExpressions.pptx)
+ - [Luna's slides (PPT)](https://docs.google.com/presentation/d/18hulaiojF5iCn5cFMQOPCo33P_5Z4JKOwmARj3d9Bfc/edit?usp=sharing)
  - [Luna's slides (PDF)]({{site.url}}/assets/talks/2019/LunaKirkby-CursedRegularExpressions.pdf)
-
+ 
 #### Lucy Rycroft-Smith: Ten New Maths Jokes
 Most maths jokes are terrible.  It's time for some brand new ones...
 
@@ -309,8 +283,7 @@ Most maths jokes are terrible.  It's time for some brand new ones...
 #### Alison Kiddle: Adventures with Dodecahedra
 Dodecahedra are pretty cool! In this talk, I will share some of my favourite dodecahedral things you can make and do.
 
- - [Alison's slides (PPT)]({{site.url}}/assets/talks/2019/AlisonKiddle-AdventureswithDodecahedra.pptx)
- - [Alison's slides (PDF)]({{site.url}}/assets/talks/2019/AlisonKiddle-AdventureswithDodecahedra.pdf)
+ - [Summary of Alison's talk](https://alisonkiddle.co.uk/mathsjam2019/)
 
 #### Louise Mabbs: Circling the Square & my Mathematical Magic progressions
 Louise demonstrates a selection of mathematical quilts, based on rainbows and polar coordinates giving beautiful circle and spiral shapes.
@@ -327,5 +300,3 @@ A little graph theory. This talk will probably give you a hangover instead of he
 #### Tarim : Horseshoe Orbits
 Why do the planets and moons in the solar system all spin in the same direction (mostly)? And what does this have to do with the stranger motions of two of the moons of Saturn?
 
- - [Tarim's slides (PPT)]({{site.url}}/assets/talks/2019/Tarim-HorseshoeOrbits.pptx)
- - [Tarim's slides (PDF)]({{site.url}}/assets/talks/2019/Tarim-HorseshoeOrbits.pdf)


### PR DESCRIPTION
Deleted links for talks with no slides
Deleted pptx links for talks with pdf only
Updated other links to match files provided - details sent in email to Katie S and copied below

1A - No slides for Adam Townsend, and no txt doc saying there shouldn't be any - I've left the links in for now.

1C - I've made an executive decision not to link to my slides, because they are rubbish by themselves and the PDF is just a mess. I've added a link to a video reading and text of poem instead.

1D - Gavan Fantom has two sets of slides. I've amended the links to reflect this, but he might want to include just one set or the other. Also, his slides are .odp format; I don't know what this is but they opened in PowerPoint when I tried them so I've just changed the links to match.

2A - Matt Peperell used own laptop - I've left the links in for now in case he has provided you with slides.

2B - Andrew Taylor used a couple of links - I'm not sure if these are to go on the archive page or not (there is another link in the talk description) so have left for now.

2B - Christian Lawson-Perfect has Google link for slides. I've left the PDF link in for now in case you want to create a PDF from Google - I imagine this is possible but have no idea how.

2C - Sydney Weaver - ditto Christian LP

2C - Luna Kirkby - ditto Christian LP

2D - Alison Kiddle - provided link to website; I've amended link on archive to reflect this