### PR TITLE
Update date for Turin MJ

### DIFF
--- a/cities/turin.md
+++ b/cities/turin.md
@@ -16,6 +16,6 @@ location:
     lon: 7.6781976
     lat: 45.0541234
 hiatus: False
-changed_dates:
-    - 2019-12-11
+changed_dates: 
+    - 2020-01-22
 ---


### PR DESCRIPTION
Update the date for the next MathsJam in Turin to Wed 22 Jan 2020