### PR TITLE
Change Christchurch MathsJam Venue

### DIFF
--- a/cities/christchurch.md
+++ b/cities/christchurch.md
@@ -12,7 +12,7 @@ organiser:
 location:
     group: rest-of-world
     pub_name: "The Good Home Ferrymead Gastropub"
-    description: "In the Ferrymead Central Complex, just off Ferry Road"
+    description: " in the Ferrymead Central Complex, just off Ferry Road"
     url: http://www.thegoodhomeferrymead.co.nz/
     lon: 172.6976229
     lat: -43.5559692

--- a/cities/christchurch.md
+++ b/cities/christchurch.md
@@ -11,11 +11,11 @@ organiser:
     email: christchurch@mathsjam.com
 location:
     group: rest-of-world
-    pub_name: "Wool Street Bar & Grill"
-    description: " on Ferry Road"
-    url: https://www.woolstreet.co.nz/
-    lon: 172.6808036
-    lat: -43.5495069
+    pub_name: "The Good Home Ferrymead Gastropub"
+    description: "In the Ferrymead Central Complex, just off Ferry Road"
+    url: http://www.thegoodhomeferrymead.co.nz/
+    lon: 172.6976229
+    lat: -43.5559692
 hiatus: False
 hiatus_months:
     - 2017-05


### PR DESCRIPTION
Updating venue from Wool Street Bar & Grill (now closed) to our new venue, The Good Home Ferrymead.