### PR TITLE
Update Oceania MathsJam Gathering link.

### DIFF
--- a/gathering/oceania/index.md
+++ b/gathering/oceania/index.md
@@ -3,10 +3,10 @@ layout: gathering
 title: MathsJam Annual Gathering Oceania
 ---
 
-# [Click here for the Oceania MathsJam Gathering website](https://omg.positronic.nz/welcome)
+# [Click here for the Oceania MathsJam Gathering website](https://mathsjam.nz)
 
 The Oceania MathsJam Gathering (OMG) is a get-together for like-minded maths enthusiasts of all abilities, ages and backgrounds — regular MathsJam attendees, teachers, recreational puzzlers, and professionals (in short, anyone who enjoys maths!) — to discuss interests, share maths problems/games/insights/ideas, make connections and generally have fun in a relaxed atmosphere.
 
 All attendees are invited to give an informal 5 minute talk about an area of interest. These are given in scheduled blocks over the weekend, interspersed with activities, and opportunities to share (maths crafts/hobbies/games/curios/areas of interest) in a more social setting. This event is a spin-off of the UK MathsJams Gathering, on our side of the world, and in our wintertime.
 
-You can access details about the next OMG, and read the archives at the [Oceania MathsJam Gathering website](https://mathsjam.nz/welcome).
+You can access details about the next OMG, and read the archives at the [Oceania MathsJam Gathering website](https://mathsjam.nz).

--- a/gathering/oceania/index.md
+++ b/gathering/oceania/index.md
@@ -9,4 +9,4 @@ The Oceania MathsJam Gathering (OMG) is a get-together for like-minded maths ent
 
 All attendees are invited to give an informal 5 minute talk about an area of interest. These are given in scheduled blocks over the weekend, interspersed with activities, and opportunities to share (maths crafts/hobbies/games/curios/areas of interest) in a more social setting. This event is a spin-off of the UK MathsJams Gathering, on our side of the world, and in our wintertime.
 
-You can access details about the next OMG, and read the archives at the [Oceania MathsJam Gathering website](https://omg.positronic.nz/welcome).
+You can access details about the next OMG, and read the archives at the [Oceania MathsJam Gathering website](https://mathsjam.nz/welcome).


### PR DESCRIPTION
The old domain still serves 301 responses to the new domain, but it's better to keep links updated.