### PR TITLE
Change Christchurch Dec 2022 date

### DIFF
--- a/cities/christchurch.md
+++ b/cities/christchurch.md
@@ -23,6 +23,7 @@ hiatus_months:
 changed_dates:
     - 2017-12-19
     - 2021-12-21
+    - 2022-12-20
 jam_date_rule: third Tuesday
 start_time: 7pm in the evening
 ---


### PR DESCRIPTION
The third Tuesday still suits most of our regular MJ attendees better, so we've decided to stick with the 20-12-2022 date instead of bringing it a week earlier. Added date in changed_dates to reflect this.