### PR TITLE
Update leuven.md

### DIFF
--- a/cities/leuven.md
+++ b/cities/leuven.md
@@ -7,7 +7,7 @@ lang: en
 email: leuven@mathsjam.com
 organiser:
     name: Dieter
-    email: leuvenMJ@gmail.com
+    email: leuven@mathsjam.com
 location:
     group: rest-of-world
     pub_name: Cafe Entrepot

--- a/cities/leuven.md
+++ b/cities/leuven.md
@@ -7,11 +7,11 @@ lang: en
 email: leuven@mathsjam.com
 organiser:
     name: Dieter
-    email: leuven@mathsjam.com
+    email: leuvenMJ@gmail.com
 location:
     group: rest-of-world
     pub_name: Cafe Entrepot
-    description: ', at the Opek Arts Centre at Vaartkom 4'
+    description: ', at the Opek Arts Centre at Vaartkom 4 (although we're scouting a new, bigger venue, stay tuned)'
     url: https://www.opek.be/
     lon: 4.7002493
     lat: 50.8877297
@@ -22,8 +22,7 @@ hiatus_months:
 start_time: 20:00 - 23:00
 links:
     twitter:
-        text: '@https://twitter.com/dietercastel'
-        url: https://twitter.com/https://twitter.com/dietercastel
-
+        text: '@dietercastel'
+        url: https://twitter.com/dietercastel
 ---
 


### PR DESCRIPTION
Small updates, a fix here and there. New email address since we're growing quite nicely (regularly 8-ish peeps) I set up a separate email address.

@katiesteckles Could leuven@mathsjam.com redirect to leuvenMJ@gmail.com instead of my personal email? 

We're also looking for a bigger/better venue so an update might follow soon.