### PR TITLE
Changed date of Christchurch December MathsJam

### DIFF
--- a/cities/christchurch.md
+++ b/cities/christchurch.md
@@ -22,6 +22,7 @@ changed_dates:
     - 2017-12-19
     - 2021-12-21
     - 2022-12-20
+    - 2023-12-19
 jam_date_rule: third Tuesday
 start_time: 7pm in the evening
 links:


### PR DESCRIPTION
Christchurch MathsJam will be taking place on the usual third Tuesday of the month, Tuesday 19th December. Edited changed_dates in christchurch.md to account for this.