### PR TITLE
Updated September 2025 dates for Christchurch MathsJam

### DIFF
--- a/cities/christchurch.md
+++ b/cities/christchurch.md
@@ -23,7 +23,7 @@ changed_dates:
     - 2021-12-21
     - 2022-12-20
     - 2023-12-19
-    - 2025-9-23
+    - 2025-09-23
 jam_date_rule: third Tuesday
 start_time: 7pm in the evening
 links:

--- a/cities/christchurch.md
+++ b/cities/christchurch.md
@@ -23,6 +23,7 @@ changed_dates:
     - 2021-12-21
     - 2022-12-20
     - 2023-12-19
+    - 2025-9-23
 jam_date_rule: third Tuesday
 start_time: 7pm in the evening
 links:


### PR DESCRIPTION
Our usual and backup venues are both fully booked out for an event in September 2025 on our usual third Tuesday date. So instead of Sept 16th we have shifted the booking to a week later, Tues Sept 23rd. Added new date under changed_dates.