### PR TITLE
Coventry summer hiatus

### DIFF
--- a/cities/coventry.md
+++ b/cities/coventry.md
@@ -18,6 +18,8 @@ hiatus: false
 hiatus_months:
     - 2024-07
     - 2024-08
+    - 2025-08
+    - 2025-09
 december_jam_date_rule: second Tuesday
 start_time: 7pm in the evening
 ---


### PR DESCRIPTION
On break during August and September.