### PR TITLE
Temporary venue change christchurch.md

### DIFF
--- a/cities/christchurch.md
+++ b/cities/christchurch.md
@@ -9,11 +9,11 @@ organiser:
     email: christchurch@mathsjam.com
 location:
     group: rest-of-world
-    pub_name: The Craft Embassy
-    description: ' in the Greenhouse pavilion on Level 1 of the Terrace, at 126 Oxford Tce'
-    url: https://www.craftembassy.co.nz
-    lon: 172.634268
-    lat: -43.532654
+    pub_name: Cascade Stranges Lane
+    description: ' in the upstairs area, at 219 High Street'
+    url: https://www.cascadebar.co.nz
+    lon: 172.638981
+    lat: -43.533884
 hiatus: false
 hiatus_months:
     - 2017-05


### PR DESCRIPTION
Christchurch MathsJam is meeting at Cascade Stranges Lane (instead of our usual location at Craft Embassy) for our June meetup, so have updated the venue information. Anticipate changing this back again after the June 16th meeting.